### PR TITLE
Rebuild for pytorch 2.5

### DIFF
--- a/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libsentencepiece:
-- 0.1.99
+- 0.2.0
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -25,9 +25,9 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 re2:
-- 2023.09.01
+- 2024.07.02
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libsentencepiece:
-- 0.1.99
+- 0.2.0
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -25,9 +25,9 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 re2:
-- 2023.09.01
+- 2024.07.02
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libsentencepiece:
-- 0.1.99
+- 0.2.0
 numpy:
 - '1.23'
 pin_run_as_build:
@@ -25,9 +25,9 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 re2:
-- 2023.09.01
+- 2024.07.02
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/migrations/pytorch25.yaml
+++ b/.ci_support/migrations/pytorch25.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for pytorch 2.5
+  kind: version
+  migration_number: 1
+libtorch:
+- '2.5'
+migrator_ts: 1730666768.682698
+pytorch:
+- '2.5'

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libsentencepiece:
-- 0.1.99
+- 0.2.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
@@ -27,9 +27,9 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 re2:
-- 2023.09.01
+- 2024.07.02
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libsentencepiece:
-- 0.1.99
+- 0.2.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
@@ -27,9 +27,9 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 re2:
-- 2023.09.01
+- 2024.07.02
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libsentencepiece:
-- 0.1.99
+- 0.2.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
@@ -27,9 +27,9 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 re2:
-- 2023.09.01
+- 2024.07.02
 target_platform:
 - osx-64
 zip_keys:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,0 @@
-# due to abseil constraint of libsentencepiece 0.1
-re2:
-  - 2023.09.01
-
-libsentencepiece:
-  - 0.1.99


### PR DESCRIPTION
sentencepiece only exists for newer abseil, so the bot stumbles over the old pin. 

I don't have high hopes though, because upstream development stopped and this particular [issue](https://github.com/pytorch/text/issues/2274) with sentencepiece won't be fixed.